### PR TITLE
min() and max() in utils library

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,9 @@
+#ifndef __UTILS_H
+#define __UTILS_H
+
+#ifndef __EXTERN
+int max(int a, int b);
+int min(int a, int b);
+
+#endif
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,16 @@
+add_library(utils STATIC utils/utils.c)
+target_include_directories(utils PUBLIC "${PROJECT_SOURCE_DIR}/include/")
+
 add_library(suffix_array STATIC suffix_array/suffix_array.c suffix_array/lcp_array.c suffix_array/lpf_array.c)
+target_link_libraries(suffix_array PUBLIC utils)
 add_executable(suffix_array_example suffix_array/suffix_array_example.c)
 target_include_directories(suffix_array PUBLIC "${PROJECT_SOURCE_DIR}/include/")
-target_link_libraries(suffix_array_example PUBLIC suffix_array)
+target_link_libraries(suffix_array_example PUBLIC suffix_array utils)
 
 add_library(list STATIC list/array_list.c)
 target_include_directories(list PUBLIC "${PROJECT_SOURCE_DIR}/include/")
+target_link_libraries(list PUBLIC utils)
 
 add_library(lz77_block STATIC lz77/lz77_block.c)
 target_include_directories(lz77_block PUBLIC "${PROJECT_SOURCE_DIR}/include/")
-target_link_libraries(lz77_block PUBLIC list)
-target_link_libraries(lz77_block PUBLIC suffix_array)
-target_link_libraries(lz77_block PUBLIC lcp_array)
+target_link_libraries(lz77_block PUBLIC suffix_array list utils)

--- a/src/lz77/lz77_block.c
+++ b/src/lz77/lz77_block.c
@@ -2,12 +2,8 @@
 #include <lz77.h>
 #include <list.h>
 #include <suffix_array.h>
+#include <utils.h>
 
-int min(int a, int b)
-{
-    if (a < b) return a;
-    return b;
-}
 
 int *sa, *reverse_sa, *lcparr;
 array_list lcp_list;

--- a/src/suffix_array/lpf_array.c
+++ b/src/suffix_array/lpf_array.c
@@ -10,12 +10,7 @@
 #include <stdlib.h>
 #include <list.h>
 #include <string.h>
-
-int min(int a, int b)
-{
-	if (a < b) return a;
-	return b;
-};
+#include <utils.h>
 
 void compute_lpf_array(array_list *lcp_list, int* sa, int *reverse_sa, const char *text, int **lpf_out, int **lpf_come_from_out)
 {

--- a/src/suffix_array/suffix_array.c
+++ b/src/suffix_array/suffix_array.c
@@ -10,12 +10,8 @@
 #include <string.h>
 #include <suffix_array.h>
 #include <stdlib.h>
+#include <utils.h>
 
-int max(int a, int b)
-{
-    if (a > b) return a;
-    return b;
-}
 
 //Technically, this algorithm sorts cyclic shifts of a string, but it can be easily used to compute suffix array, just by appending a terminator character,
 //which is less than any other character in string, to the end of string 

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -1,0 +1,12 @@
+#include <utils.h>
+
+int max(int a, int b)
+{
+	if (a > b) return a;
+	return b;
+}
+int min(int a, int b)
+{
+	if (a < b) return a;
+	return b;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,7 +75,7 @@ add_test(NAME "LPF Array Manual \"aaaaaaaaaaaaaaaa\"" COMMAND $<TARGET_FILE:lpf_
 add_test(NAME "LPF Array Manual \"lOrEM iPSUm dOloR sIt\"" COMMAND $<TARGET_FILE:lpf_array_test_manual> "lOrEM iPSUm dOloR sIt")
 add_test(NAME "LPF Array Manual \"to jest losowy tekst pisany w jezyku polskim ktory ma na celu przetestowac popwanosc liczenia tablicy lpf\"" COMMAND $<TARGET_FILE:lpf_array_test_manual> "to jest losowy tekst pisany w jezyku polskim ktory ma na celu przetestowac popwanosc liczenia tablicy lpf")
 add_test(NAME "LPF Array Manual \"aabaabaabaabaabaabaabaabaab\"" COMMAND $<TARGET_FILE:lpf_array_test_manual> "aabaabaabaabaabaabaabaabaab")
-add_test(NAME "LPF Array Manual \"(ab)^100\"" COMMAND $<TARGET_FILE:lpf_array_test_manual> "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab"
+add_test(NAME "LPF Array Manual \"(ab)^100\"" COMMAND $<TARGET_FILE:lpf_array_test_manual> "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab")
 
 add_executable(lpf_array_test_auto lpf_array_test_auto.cpp)
 target_include_directories(lpf_array_test_auto PUBLIC "${PROJECT_SOURCE_DIR}/include/")


### PR DESCRIPTION
In the previously written code I was sometimes using min() and max() functions. I  was defining them separately in every file I needed. This led me once to multideclaration problem, so I decided to make a new library for them. The new library's name is "utils", and, if needed, in future it will contain more general-use functions.